### PR TITLE
fix: replace invalid Dockerfile CMD with list-clips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ USER appuser
 ENV OPENCV_IO_ENABLE_OPENEXR=1
 
 ENTRYPOINT ["/app/.venv/bin/python", "corridorkey_cli.py"]
-CMD ["--action", "list"]
+CMD ["list-clips"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,17 @@ class TestInvalidArgs:
         result = runner.invoke(app, ["nonexistent"])
         assert result.exit_code != 0
 
+    def test_action_flag_is_not_a_valid_argument(self):
+        """--action is not a recognized option; using it must fail."""
+        result = runner.invoke(app, ["--action", "list"])
+        assert result.exit_code != 0
+
+    def test_list_clips_is_a_valid_subcommand(self):
+        """list-clips must succeed as the intended default Docker CMD."""
+        with patch("clip_manager.scan_clips", return_value=[]):
+            result = runner.invoke(app, ["list-clips"])
+        assert result.exit_code == 0
+
 
 # ---------------------------------------------------------------------------
 # InferenceSettings defaults


### PR DESCRIPTION
Fixes #4.

## Problem

The Dockerfile's default `CMD` was `["--action", "list"]`. The CLI uses Typer subcommands (`list-clips`, `run-inference`, `generate-alphas`, `wizard`) and has no `--action` option. Any `docker run corridorkey` invocation without an explicit command would fail immediately at startup.

## Solution

Changed `CMD` to `["list-clips"]`, which lists clips from the configured directory and mirrors the intended default behaviour.

## Tests

Two new tests in `TestInvalidArgs`:
- `test_action_flag_is_not_a_valid_argument`: confirms `--action list` returns a non-zero exit code.
- `test_list_clips_is_a_valid_subcommand`: confirms `list-clips` exits successfully.

### Before

```
Uninstalled 2 packages in 115ms
Installed 2 packages in 813ms
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/thiago/dev/corridorkey/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/thiago/dev/corridorkey
configfile: pyproject.toml
plugins: hypothesis-6.151.9, cov-7.0.0, anyio-4.12.1
collecting ... collected 4 items

tests/test_cli.py::TestInvalidArgs::test_wizard_requires_path PASSED     [ 25%]
tests/test_cli.py::TestInvalidArgs::test_unknown_subcommand PASSED       [ 50%]
tests/test_cli.py::TestInvalidArgs::test_action_flag_is_not_a_valid_argument PASSED [ 75%]
tests/test_cli.py::TestInvalidArgs::test_list_clips_is_a_valid_subcommand PASSED [100%]

============================== 4 passed in 2.45s ===============================
```

### After

```
........................................................................ [ 30%]
........................................................................ [ 61%]
........................................................................ [ 91%]
....................                                                     [100%]
236 passed, 2 deselected in 3.74s
```